### PR TITLE
Update client.js

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -161,7 +161,7 @@ module.exports = class Client {
    */
   async getUser(key) {
     return new Promise(async (resolve, reject) => {
-      let access;
+      let access = {};
       try {
         access = jwt.verify(key, this._secret);
       } catch (err) {


### PR DESCRIPTION
Fix Error: Uncaught (in promise) TypeError: Cannot read property 'access_token' of undefined
This happens when `access` is undefined (by default). This error has been spamming the Node.js console, while the login etc. still works.